### PR TITLE
Added option to only mark migration up/down as applied on success

### DIFF
--- a/chmigrate/migrator.go
+++ b/chmigrate/migrator.go
@@ -167,7 +167,7 @@ func (m *Migrator) Migrate(ctx context.Context, opts ...MigrationOption) (*Migra
 			}
 		}
 
-		if applyErr := m.MarkApplied(ctx, migration); err != nil {
+		if applyErr := m.MarkApplied(ctx, migration); applyErr != nil {
 			return group, applyErr
 		}
 
@@ -211,7 +211,7 @@ func (m *Migrator) Rollback(ctx context.Context, opts ...MigrationOption) (*Migr
 			}
 		}
 
-		if unapplyErr := m.MarkUnapplied(ctx, migration); err != nil {
+		if unapplyErr := m.MarkUnapplied(ctx, migration); unapplyErr != nil {
 			return lastGroup, unapplyErr
 		}
 

--- a/chmigrate/migrator.go
+++ b/chmigrate/migrator.go
@@ -27,11 +27,11 @@ func WithLocksTableName(table string) MigratorOption {
 	}
 }
 
-// WithApplyOnSuccess sets the migrator to only mark migrations as applied/unapplied
+// WithMarkAppliedOnSuccess sets the migrator to only mark migrations as applied/unapplied
 // when their up/down is successful
-func WithApplyOnSuccess() MigratorOption {
+func WithMarkAppliedOnSuccess() MigratorOption {
 	return func(m *Migrator) {
-		m.applyOnSuccess = true
+		m.markAppliedOnSuccess = true
 	}
 }
 
@@ -41,9 +41,9 @@ type Migrator struct {
 
 	ms MigrationSlice
 
-	table          string
-	locksTable     string
-	applyOnSuccess bool
+	table                string
+	locksTable           string
+	markAppliedOnSuccess bool
 }
 
 func NewMigrator(db *ch.DB, migrations *Migrations, opts ...MigratorOption) *Migrator {
@@ -162,7 +162,7 @@ func (m *Migrator) Migrate(ctx context.Context, opts ...MigrationOption) (*Migra
 		if !cfg.nop || migration.Up != nil {
 			err = migration.Up(ctx, m.db)
 			// If the migration failed and we only apply on success, return error
-			if err != nil && m.applyOnSuccess {
+			if err != nil && m.markAppliedOnSuccess {
 				return group, err
 			}
 		}
@@ -206,7 +206,7 @@ func (m *Migrator) Rollback(ctx context.Context, opts ...MigrationOption) (*Migr
 		if !cfg.nop && migration.Down != nil {
 			err = migration.Down(ctx, m.db)
 			// If the rollback failed and we only mark unapplied on success, return error
-			if err != nil && m.applyOnSuccess {
+			if err != nil && m.markAppliedOnSuccess {
 				return lastGroup, err
 			}
 		}


### PR DESCRIPTION
Adds an option that instructs the Migrator to make migrations applied on success and not on both success and failure. Something to note, the group is being returned in more of the error paths than before, I think this is consistent with the intent that despite a migration failing some migrations were still applied and that is information that the API consumer will want to know.